### PR TITLE
Fixed the copyright notice.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 zoria-lang
+Copyright (c) 2020 Jakub Grobelny, Kamil Michalak, Łukasz Deptuch
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The LICENSE file had "zoria-lang" as the copyright owner due
to the fact it was automatically generated. It has been fixed
and now has our names instead.